### PR TITLE
alpine workaround

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -51,7 +51,7 @@ RUN go get github.com/ssllabs/ssllabs-scan
 FROM alpine:latest AS builder
 RUN \
   apk add --no-cache nodejs-current npm && rm -rf /var/cache/apk/* \
-  && npm install -g observatory-cli
+  && npm config set unsafe-perm true && npm install -g observatory-cli
 RUN \
   apk add --no-cache composer php7-curl php7-xml && rm -rf /var/cache/apk/* \
   && composer global require bramus/mixed-content-scan


### PR DESCRIPTION
there is know bug around alpine/npm described here https://github.com/npm/uid-number/issues/3, build works fine ran from root, but from other non-root user it fails (at least for me), adding "workaround" as described in issue "patches" problem, otherwise an error may occur like this
```
...
Step 4/18 : FROM alpine:latest AS builder
 ---> 3f53bb00af94
Step 5/18 : RUN   apk add --no-cache nodejs-current npm && rm -rf /var/cache/apk/*   && npm install -g observatory-cli
 ---> Running in d08da129531d
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/10) Installing ca-certificates (20171114-r3)
(2/10) Installing c-ares (1.14.0-r0)
(3/10) Installing libcrypto1.0 (1.0.2q-r0)
(4/10) Installing libgcc (6.4.0-r9)
(5/10) Installing http-parser (2.8.1-r0)
(6/10) Installing libssl1.0 (1.0.2q-r0)
(7/10) Installing libstdc++ (6.4.0-r9)
(8/10) Installing libuv (1.20.2-r0)
(9/10) Installing nodejs-current (9.11.1-r2)
(10/10) Installing npm (8.14.0-r0)
Executing busybox-1.28.4-r2.trigger
Executing ca-certificates-20171114-r3.trigger
OK: 55 MiB in 23 packages
[91mError: could not get uid/gid
[ 'nobody', 0 ]

    at /usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
    at ChildProcess.exithandler (child_process.js:280:5)
    at ChildProcess.emit (events.js:180:13)
    at maybeClose (internal/child_process.js:936:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:220:5)
[0m[91mTypeError: Cannot read property 'get' of undefined
    at errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
    at /usr/lib/node_modules/npm/bin/npm-cli.js:78:20
    at cb (/usr/lib/node_modules/npm/lib/npm.js:228:22)
    at /usr/lib/node_modules/npm/lib/npm.js:266:24
    at /usr/lib/node_modules/npm/lib/config/core.js:83:7
    at Array.forEach (<anonymous>)
    at /usr/lib/node_modules/npm/lib/config/core.js:82:13
    at f (/usr/lib/node_modules/npm/node_modules/once/once.js:25:25)
    at afterExtras (/usr/lib/node_modules/npm/lib/config/core.js:173:20)
    at Conf.<anonymous> (/usr/lib/node_modules/npm/lib/config/core.js:231:22)
[0m[91m/usr/lib/node_modules/npm/lib/utils/error-handler.js:205
  if (npm.config.get('json')) {
```