### PR TITLE
Fix docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ or build docker image:
 git clone https://github.com/trimstray/htrace.sh
 
 # Go to build/ directory and build docker image
-cd htrace.sh/build && docker build --rm -t htrace.sh -f Dockerfile .
+cd htrace.sh && build/build.sh
 
 # Run the app
 docker run --rm -it --name htrace.sh htrace.sh -u http://nmap.org -s -h

--- a/bin/htrace.sh
+++ b/bin/htrace.sh
@@ -49,7 +49,7 @@ if [[ "$OSTYPE" == "darwin"* ]] ; then
   # shellcheck disable=SC2001,SC2005
   readonly _init_directory=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
-elif [[ "$OSTYPE" == "linux-gnu" ]] ; then
+elif [[ "$OSTYPE" == "linux-gnu" ]] || [[ "$OSTYPE" == "linux-musl" ]] ; then
 
   # Store the name of the script and directory call.
   readonly _init_name="$(basename "$0")"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -88,12 +88,16 @@ COPY --from=builder /usr/lib/node_modules/observatory-cli/index.js /usr/bin/obse
 COPY --from=builder /root/.composer/vendor/bramus/mixed-content-scan/bin/mixed-content-scan /usr/bin/mixed-content-scan
 COPY --from=testssl /usr/local/bin/testssl.sh /usr/bin/testssl.sh
 
-RUN \
-  mkdir -p /opt && cd /opt \
-  && git clone https://github.com/trimstray/htrace.sh.git \
-  && cd htrace.sh \
-  && mkdir -p /opt/htrace.sh/log/ \
-  && bash setup.sh install
+WORKDIR /opt/htrace.sh
+
+COPY bin /opt/htrace.sh/bin/
+COPY lib /opt/htrace.sh/lib/
+COPY log /opt/htrace.sh/log/
+COPY src /opt/htrace.sh/src/
+COPY static /opt/htrace.sh/static/
+COPY dependencies.sh setup.sh /opt/htrace.sh/
+
+RUN ./setup.sh install
 
 ENTRYPOINT ["/usr/local/bin/htrace.sh"]
 CMD ["--help"]

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+echo $ROOT_DIR
+cd $ROOT_DIR
+
+docker build -t htrace.sh -f build/Dockerfile .

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,6 @@
 set -eux
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-echo $ROOT_DIR
 cd $ROOT_DIR
 
 docker build -t htrace.sh -f build/Dockerfile .

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" == "darwin"* ]] ; then
 
   readonly _dir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
-elif [[ "$OSTYPE" == "linux-gnu" ]] ; then
+elif [[ "$OSTYPE" == "linux-gnu" ]] || [[ "$OSTYPE" == "linux-musl" ]] ; then
 
   readonly _dir=$(dirname "$(readlink -f "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 


### PR DESCRIPTION
This patch is to fix https://github.com/trimstray/htrace.sh/issues/54

I also ditched the `git clone` step in `build/Dockerfile`, since you should have all files in local.