### PR TITLE
Fixes Docker build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -48,7 +48,7 @@ FROM golang:alpine AS golang
 RUN apk update && apk add --no-cache git
 RUN go get github.com/ssllabs/ssllabs-scan
 RUN go get github.com/maxmind/geoipupdate/cmd/geoipupdate
-RUN go get github.com/subfinder/subfinder
+RUN go get github.com/projectdiscovery/subfinder/cmd/subfinder
 
 FROM drwetter/testssl.sh:stable AS testssl
 
@@ -77,7 +77,7 @@ RUN \
   python \
   py-pip \
   rsync \
-  nghttp2
+  nghttp2 \
   && rm -rf /var/cache/apk/*
 
 RUN \
@@ -114,16 +114,18 @@ COPY --from=golang /go/bin/subfinder /usr/bin/subfinder
 COPY --from=testssl /usr/local/bin/testssl.sh /usr/bin/testssl.sh
 COPY --from=testssl /home/testssl/etc/ /etc/testssl/etc/
 
+ARG GEOIP_ACCOUNT=0
+ARG GEOIP_LICENSE=000000000000
 RUN \
   mkdir -p /usr/local/etc/ && \
-  echo -en "AccountID 0\\nLicenseKey 000000000000\\nEditionIDs GeoLite2-Country GeoLite2-City" > /usr/local/etc/GeoIP.conf
+  echo -en "AccountID ${GEOIP_ACCOUNT}\\nLicenseKey ${GEOIP_LICENSE}\\nEditionIDs GeoLite2-Country GeoLite2-City" > /usr/local/etc/GeoIP.conf
 
 RUN \
   mkdir -p /usr/local/share/GeoIP/ && \
-  geoipupdate
+  geoipupdate || true # skip error if fails due account
 
 RUN \
-  cp -R /usr/local/share/GeoIP /usr/share/
+  ln -s /usr/local/share/GeoIP /usr/share/
 
 ENV TESTSSL_INSTALL_DIR /etc/testssl
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,7 +2,6 @@
 
 set -eux
 
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-cd $ROOT_DIR
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd )"
 
-docker build -t htrace.sh -f build/Dockerfile .
+docker build -t htrace.sh -f build/Dockerfile "${ROOT_DIR}"


### PR DESCRIPTION

docker build gave couple errors:
- the `subfinder` got moved to new place
- added `geoip2` account details as build-arg
  also ignores failure if not provided (now requires sign up)

build.sh does not require `cd`
- just give path to docker build context
- also `cd` may echo directory due to `CDPATH`. suppress that.