### PR TITLE
Add nghttp to commands set

### DIFF
--- a/src/__init__
+++ b/src/__init__
@@ -320,7 +320,7 @@ function __main__() {
   # unnecessarily run.
   readonly commands=(basename dirname stat ps date grep cut sed awk chown \
                      chmod mkdir curl openssl dig mmdblookup bc jq fmt \
-                     testssl.sh observatory ssllabs-scan \
+                     testssl.sh observatory ssllabs-scan nghttp \
                      mixed-content-scan nmap wafw00f subfinder)
 
   # If you intend to specify the full path to the command we do it like:


### PR DESCRIPTION
When using `--http2` param, the program will execute command `nghttp`

But the program didn't check whether the command `nghttp` exist on start