### PR TITLE
update dockerfile with testssl.sh 3.0 version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -50,7 +50,7 @@ RUN go get github.com/ssllabs/ssllabs-scan
 RUN go get github.com/maxmind/geoipupdate/cmd/geoipupdate
 RUN go get github.com/projectdiscovery/subfinder/cmd/subfinder
 
-FROM drwetter/testssl.sh:stable AS testssl
+FROM drwetter/testssl.sh:3.0 AS testssl
 
 FROM alpine:3.9
 


### PR DESCRIPTION
Tags for testssl.sh were updated at https://hub.docker.com/r/drwetter/testssl.sh/tags and the `stable` tag the Dockerfile was using no longer exists.

The only available "stable" tag is `3.0`. The other tags (at the time of writing) are `latest` and `3.1dev` which cannot be considered stable.