### PR TITLE
Use `-n` instead of double-negative `! -z` in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # Tasks for specific system version.
 if [[ "$OSTYPE" == "darwin"* ]] ; then
 
-  [ ! -z "$(brew --prefix)" ] && PATH=$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH
+  [ -n "$(brew --prefix)" ] && PATH=$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH
 
   readonly _dir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 


### PR DESCRIPTION
Could be easier to understand / read the code without double-negative logic.