### PR TITLE
Fix $HTRACE_COLORS $HIDE_SRC_IP checking logic in helpers

### DIFF
--- a/src/helpers
+++ b/src/helpers
@@ -816,8 +816,7 @@ function _before_init() {
 
     export HTRACE_COLORS="on"
 
-  elif [[ "$HTRACE_COLORS" != "on" ]] || \
-       [[ "$HTRACE_COLORS" != "off" ]] ; then
+  elif [[ "$HTRACE_COLORS" != "off" ]] ; then
 
     export HTRACE_COLORS="on"
 
@@ -905,8 +904,7 @@ function _before_init() {
 
     export HIDE_SRC_IP="off"
 
-  elif [[ "$HIDE_SRC_IP" != "on" ]] || \
-       [[ "$HIDE_SRC_IP" != "off" ]] ; then
+  elif [[ "$HIDE_SRC_IP" != "on" ]] ; then
 
     export HIDE_SRC_IP="off"
 


### PR DESCRIPTION
The original condition logic will ALWAYS be true, which doesn't make any
sense here as the variables here seem to be reversed even though the
values are already set, and also, if the conditions here always need to
be true; there is no need to write the long logic here.
