### PR TITLE
Fix expiration wording and fix go modules installation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,15 +46,15 @@
 
 FROM golang:alpine AS golang
 RUN apk add --no-cache git
-RUN go get github.com/ssllabs/ssllabs-scan
-RUN go get github.com/maxmind/geoipupdate/cmd/geoipupdate
-RUN go get github.com/projectdiscovery/subfinder/v2/cmd/subfinder
+RUN go install github.com/ssllabs/ssllabs-scan@latest
+RUN go install github.com/maxmind/geoipupdate/cmd/geoipupdate@latest
+RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 
 FROM drwetter/testssl.sh:3.0 AS testssl
 
 FROM alpine:3.14
 
-MAINTAINER trimstray "trimstray@gmail.com"
+LABEL org.opencontainers.image.authors="trimstray@gmail.com"
 
 RUN \
   apk add --no-cache \

--- a/lib/DomainCertCheck
+++ b/lib/DomainCertCheck
@@ -236,48 +236,48 @@ function DomainCertCheck() {
         # Less then 1h
         if [[ "$_expiry_epoch_to_end" -lt 3600 ]] ; then
 
-          _expr_time_msg="$_time_to_expire to expired"
+          _expr_time_msg="expires in $_time_to_expire"
           _expr_timtrgb="$trgb_3310"
 
         # Less then 3h
         elif [[ "$_expiry_epoch_to_end" -lt 10800 ]] ; then
 
-          _expr_time_msg="$_time_to_expire to expired"
+          _expr_time_msg="expires in $_time_to_expire"
           _expr_timtrgb="$trgb_3310"
 
         # Less then 6h
         elif [[ "$_expiry_epoch_to_end" -lt 21600 ]] ; then
 
-          _expr_time_msg="$_time_to_expire to expired"
+          _expr_time_msg="expires in $_time_to_expire"
           _expr_timtrgb="$trgb_3310"
 
         # Less then 12h
         elif [[ "$_expiry_epoch_to_end" -lt 43200 ]] ; then
 
-          _expr_time_msg="$_time_to_expire to expired"
+          _expr_time_msg="expires in $_time_to_expire"
           _expr_timtrgb="$trgb_3310"
 
         # Less then 24h
         else
 
-          _expr_time_msg="$_time_to_expire to expired"
+          _expr_time_msg="expires in $_time_to_expire"
           _expr_timtrgb="$trgb_3310"
 
         fi
 
       elif [[ "$_expiry_epoch_to_end_days" -le 7 ]] ; then
 
-        _expr_time_msg="$_expiry_epoch_to_end_days days to expired"
+        _expr_time_msg="expires in $_expiry_epoch_to_end_days days"
         _expr_timtrgb="$trgb_3310"
 
       elif [[ "$_expiry_epoch_to_end_days" -le 14 ]] ; then
 
-        _expr_time_msg="$_expiry_epoch_to_end_days days to expired"
+        _expr_time_msg="expires in $_expiry_epoch_to_end_days days"
         _expr_timtrgb="$trgb_3300"
 
       else
 
-        _expr_time_msg="$_expiry_epoch_to_end_days days to expired"
+        _expr_time_msg="expires in $_expiry_epoch_to_end_days days"
         _expr_timtrgb="$trgb_3200"
 
       fi


### PR DESCRIPTION
- Replace `(xx days to expired)` by `(expires in xx days)` which is grammatically correct
- Replace `go get` by `go install` to fix the following deprecation
    > 'go get' is no longer supported outside a module.
    > To build and install a command, use 'go install' with a version,
    > like 'go install example.com/cmd@latest'
    > For more information, see https://golang.org/doc/go-get-install-deprecation
    > or run 'go help get' or 'go help install'.

- Replace deprecated `MAINTAINER` tag in Dockerfile with `LABEL` (see https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)