### PR TITLE
Update Dockerfile base image to Alpine v3.15

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,7 +52,7 @@ RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 
 FROM drwetter/testssl.sh:3.0 AS testssl
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL org.opencontainers.image.authors="trimstray@gmail.com"
 


### PR DESCRIPTION
Alpine Linux v3.14 has reached its End of Life (EOL) already months ago. 

Unlike to upgrade to Alpine linux v3.15, upgrade to version >= v3.16 will need some additional adjustments, make more changes, to keep the change minimized and get the it out of EOL version version, just upgrade it to v3.15 first here.