### PR TITLE
fix docker build error: cannot install geoipupdate

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -47,7 +47,7 @@
 FROM golang:alpine AS golang
 RUN apk add --no-cache git
 RUN go install github.com/ssllabs/ssllabs-scan@latest
-RUN go install github.com/maxmind/geoipupdate/cmd/geoipupdate@latest
+RUN go install github.com/maxmind/geoipupdate/v7/cmd/geoipupdate@latest
 RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 
 FROM drwetter/testssl.sh:3.0 AS testssl


### PR DESCRIPTION
Hello

For latest master version we cannot build docker image.
This PR update geoipupdate version. 

The old version requires "github.com/theckman/go-flock" instead of "github.com/gofrs/flock". 
See for example - [Update README to replace references to theckman/go-flock](https://github.com/gofrs/flock/commit/7ef9624944c92f8f2512520d353436895bcfee70)

```
[.......]
Step 4/35 : RUN go install github.com/maxmind/geoipupdate/cmd/geoipupdate@latest
 ---> Running in d42a9abc86bd
go: downloading github.com/maxmind/geoipupdate v4.0.2+incompatible
go: finding module for package github.com/theckman/go-flock
go: finding module for package github.com/pkg/errors
go: finding module for package github.com/spf13/pflag
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/theckman/go-flock v0.9.0
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
go: found github.com/spf13/pflag in github.com/spf13/pflag v1.0.5
go: found github.com/theckman/go-flock in github.com/theckman/go-flock v0.9.0
go: github.com/maxmind/geoipupdate/cmd/geoipupdate imports
	github.com/theckman/go-flock: github.com/theckman/go-flock@v0.9.0: parsing go.mod:
	module declares its path as: github.com/gofrs/flock
	        but was required as: github.com/theckman/go-flock
The command '/bin/sh -c go install github.com/maxmind/geoipupdate/cmd/geoipupdate@latest' returned a non-zero code: 1
```

Steps to reproduce

Clone repository `git clone https://github.com/trimstray/htrace.sh.git`
Build image `cd htrace.sh && build/build.sh`
The error appear during installing geoipupdate.
